### PR TITLE
Test run demo pipeline in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
   - postgresql
 install:
   - pip install .[test]
-script: psql -c "SELECT version();"
+script: python test.py
 deploy:
   provider: pypi
   distributions: sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: python
-dist: xenial
+dist: bionic
 matrix:
   include:
     - python: '3.6'
     - python: '3.7'
       env: UPLOAD=True
     - python: '3.8'
+services:
+  - postgresql
 install:
   - pip install .[test]
-script: echo hello world
+script: psql -c "SELECT version();"
 deploy:
   provider: pypi
   distributions: sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ services:
   - postgresql
 install:
   - pip install .[test]
-script: python test.py
+before_script:
+  - psql -U postgres -c 'create role root superuser login;'
+script:
+  - python test.py
 deploy:
   provider: pypi
   distributions: sdist

--- a/test.py
+++ b/test.py
@@ -1,0 +1,12 @@
+import mara_db.auto_migration
+import mara_db.config
+import mara_db.dbs
+from data_integration.pipelines import demo_pipeline
+from data_integration.ui.cli import run_pipeline
+
+mara_db.config.databases \
+    = lambda: {'mara': mara_db.dbs.PostgreSQLDB(host='127.0.0.1', user='root', database='example_etl_mara')}
+
+mara_db.auto_migration.auto_discover_models_and_migrate()
+
+run_pipeline(demo_pipeline())


### PR DESCRIPTION
This is a step towards having actual tests. 

This PR extends the travis config to also contain a postgres instance and then runs the demo pipeline from https://github.com/mara/data-integration/blob/master/data_integration/pipelines.py#L309

Example output: https://travis-ci.org/mara/data-integration/jobs/658643383