### PR TITLE
add feature of 'private nodes'

### DIFF
--- a/mara_pipelines/ui/dependency_graph.py
+++ b/mara_pipelines/ui/dependency_graph.py
@@ -57,6 +57,10 @@ def dependency_graph(nodes: {str: pipelines.Node},
         return upstream_ids
 
     for node in nodes.values():
+        # hide private nodes
+        if str.startswith(node.id, '_'):
+            continue
+
         node_attributes = {'fontname': ' ',  # use website default
                            'fontsize': '10.5px'  # fontsize unfortunately must be set
                            }


### PR DESCRIPTION
Hide 'private' nodes in dependency graph.

For the mara-singer package I added an internal pipeline (https://github.com/hz-lschick/mara-singer/commit/0f5be27cfa511e62b25995b233191885373edbb3) which must be part of the root pipeline in order to use `mara_pipelines.ui.cli.run_pipeline`.

With this change, the internal `_singer` pipeline is hidden from the user UI.