### PR TITLE
use echo_queries from mara_db.config.default_echo_queries

### DIFF
--- a/mara_pipelines/commands/sql.py
+++ b/mara_pipelines/commands/sql.py
@@ -80,7 +80,7 @@ class _SQLCommand(pipelines.Command):
 class ExecuteSQL(_SQLCommand):
     def __init__(self, sql_statement: str = None, sql_file_name: Union[str, Callable] = None,
                  replace: {str: str} = None, file_dependencies=None, db_alias: str = None,
-                 echo_queries: bool = True, timezone: str = None) -> None:
+                 echo_queries: bool = None, timezone: str = None) -> None:
         """
         Runs an sql file or statement in a database
 
@@ -321,7 +321,7 @@ class CopyIncrementally(_SQLCommand):
                                          + f'CREATE TABLE {self.target_table}_upsert AS SELECT * from {self.target_table} WHERE FALSE')
 
             if not shell.run_shell_command(f'echo {shlex.quote(create_upsert_table_query)} \\\n  | '
-                                           + mara_db.shell.query_command(self.target_db_alias, echo_queries=True)):
+                                           + mara_db.shell.query_command(self.target_db_alias)):
                 return False
 
             # perform the actual copy replacing the placeholder
@@ -358,11 +358,10 @@ SELECT src.*
 FROM {self.target_table}_upsert src
 WHERE NOT EXISTS (SELECT 1 FROM {self.target_table} dst WHERE {key_definition})"""
                 if not shell.run_shell_command(f'echo {shlex.quote(update_query)} \\\n  | '
-                                               + mara_db.shell.query_command(self.target_db_alias, echo_queries=True)):
+                                               + mara_db.shell.query_command(self.target_db_alias)):
                     return False
                 elif not shell.run_shell_command(f'echo {shlex.quote(insert_query)} \\\n  | '
-                                                 + mara_db.shell.query_command(self.target_db_alias,
-                                                                               echo_queries=True)):
+                                                 + mara_db.shell.query_command(self.target_db_alias)):
                     return False
             else:
                 upsery_query = f"""
@@ -372,7 +371,7 @@ FROM {self.target_table}_upsert
 ON CONFLICT ({key_definition})
 DO UPDATE SET {set_clause}"""
                 if not shell.run_shell_command(f'echo {shlex.quote(upsery_query)} \\\n  | '
-                                               + mara_db.shell.query_command(self.target_db_alias, echo_queries=True)):
+                                               + mara_db.shell.query_command(self.target_db_alias)):
                     return False
 
         # update data_integration_incremental_copy_status

--- a/mara_pipelines/parallel_tasks/sql.py
+++ b/mara_pipelines/parallel_tasks/sql.py
@@ -11,7 +11,7 @@ class ParallelExecuteSQL(pipelines.ParallelTask, sql._SQLCommand):
     def __init__(self, id: str, description: str, parameter_function: typing.Callable, parameter_placeholders: [str],
                  max_number_of_parallel_tasks: int = None, sql_statement: str = None, file_name: str = None,
                  commands_before: [pipelines.Command] = None, commands_after: [pipelines.Command] = None,
-                 db_alias: str = None, echo_queries: bool = True, timezone: str = None,
+                 db_alias: str = None, echo_queries: bool = None, timezone: str = None,
                  replace: {str: str} = None) -> None:
 
         if (not (sql_statement or file_name)) or (sql_statement and file_name):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url = 'https://github.com/mara/mara-pipelines',
 
     install_requires=[
-        'mara-db>=4.2.0',
+        'mara-db>=4.7.1',
         'mara-page>=1.3.0',
         'graphviz>=0.8',
         'python-dateutil>=2.6.1',


### PR DESCRIPTION
Since mara_db version 4.7.1 the echo_queries parameter is by default taken from `mara_db.config.default_echo_queries` when it is `None`.

The config is by default set to True, so, we can safely remove all `echo_queries=True` calls in mara_pipeline.
With this PR the mara_db.config.default_echo_queries config will apply to mara_pipeline as well.