### PR TITLE
add a simple pipeline unit test without mara db

### DIFF
--- a/mara_pipelines/execution.py
+++ b/mara_pipelines/execution.py
@@ -323,10 +323,10 @@ def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
     run_process.start()
 
     if 'mara' in mara_db.config.databases():
-        runlogger = run_log.DbRunLogger()
-    else:
         runlogger = run_log.RunLogger()
-        print(f"[WARNING] The events of the pipeline execution are not logged", file=sys.stderr)
+    else:
+        runlogger = run_log.NullLogger()
+        print(f"[WARNING] The events of the pipeline execution are not saved in a db", file=sys.stderr)
 
     # make sure that we close this run (if still open) as failed when we close this python process
     # On SIGKILL we will still leave behind open runs...

--- a/mara_pipelines/logging/run_log.py
+++ b/mara_pipelines/logging/run_log.py
@@ -105,12 +105,12 @@ RETURNING run_id
             print(f'Cleaned up open runs/node_runs (run_id = {run_id})')
 
 
-class RunLogger(events.EventHandler):
-    """A base class for a run logger of pipeline events"""
+class NullLogger(events.EventHandler):
+    """A run logger not handling events"""
     run_id: int = None
 
 
-class DbRunLogger(RunLogger):
+class RunLogger(events.EventHandler):
     """A run logger saving the pipeline events to the 'mara' database alias"""
     node_output: {tuple: [pipeline_events.Output]} = None
 

--- a/mara_pipelines/logging/run_log.py
+++ b/mara_pipelines/logging/run_log.py
@@ -106,15 +106,15 @@ RETURNING run_id
 
 
 class RunLogger(events.EventHandler):
+    """A base class for a run logger of pipeline events"""
     run_id: int = None
+
+
+class DbRunLogger(RunLogger):
+    """A run logger saving the pipeline events to the 'mara' database alias"""
     node_output: {tuple: [pipeline_events.Output]} = None
 
     def handle_event(self, event: events.Event):
-        import mara_db.config
-
-        if 'mara' not in mara_db.config.databases():
-            return
-
         import psycopg2.extensions
         import mara_db.postgresql
 

--- a/mara_pipelines/logging/run_log.py
+++ b/mara_pipelines/logging/run_log.py
@@ -109,9 +109,13 @@ class NullLogger(events.EventHandler):
     """A run logger not handling events"""
     run_id: int = None
 
+    def handle_event(self, event: events.Event):
+        pass
+
 
 class RunLogger(events.EventHandler):
     """A run logger saving the pipeline events to the 'mara' database alias"""
+    run_id: int = None
     node_output: {tuple: [pipeline_events.Output]} = None
 
     def handle_event(self, event: events.Event):

--- a/mara_pipelines/logging/run_log.py
+++ b/mara_pipelines/logging/run_log.py
@@ -1,10 +1,8 @@
 """Logging pipeline runs, node output and status information in mara database"""
 
-import psycopg2.extensions
 import sqlalchemy.orm
 from sqlalchemy.ext.declarative import declarative_base
 
-import mara_db.postgresql
 from .. import config
 from ..logging import pipeline_events, system_statistics
 from .. import events
@@ -73,6 +71,15 @@ def close_open_run_after_error(run_id: int):
     """Closes all open run and node_run for this run_id as failed"""
     if run_id is None:
         return
+
+    import mara_db.config
+
+    if 'mara' not in mara_db.config.databases():
+        return
+
+    import psycopg2.extensions
+    import mara_db.postgresql
+
     _close_run = f'''
 UPDATE  data_integration_run
 SET end_time = now(), succeeded = FALSE
@@ -103,6 +110,13 @@ class RunLogger(events.EventHandler):
     node_output: {tuple: [pipeline_events.Output]} = None
 
     def handle_event(self, event: events.Event):
+        import mara_db.config
+
+        if 'mara' not in mara_db.config.databases():
+            return
+
+        import psycopg2.extensions
+        import mara_db.postgresql
 
         if isinstance(event, pipeline_events.RunStarted):
             with mara_db.postgresql.postgres_cursor_context('mara') as cursor:  # type: psycopg2.extensions.cursor

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,12 @@ setup(
         'requests>=2.19.1'
     ],
 
+    extras_require={
+        'test': [
+            'pytest',
+            'mara_app>=1.5.2'],
+    },
+
     setup_requires=['setuptools_scm'],
     include_package_data=True,
 

--- a/tests/test_execute_pipeline.py
+++ b/tests/test_execute_pipeline.py
@@ -1,0 +1,26 @@
+import pytest
+
+from mara_app.monkey_patch import patch
+
+import mara_db.config
+patch(mara_db.config.databases)(lambda: {})
+
+
+def test_execute_without_db():
+    from mara_pipelines.commands.python import RunFunction
+    from mara_pipelines.pipelines import Pipeline, Task
+    from mara_pipelines.ui.cli import run_pipeline
+
+    pipeline = Pipeline(
+        id='test_execute_without_db',
+        description="Tests if a pipeline can be executed without database")
+    
+    def command_function() -> bool:
+        return True
+
+    pipeline.add(
+        Task(id='run_python_function',
+             description="Runs a sample python function",
+             commands=[RunFunction(function=command_function)]))
+
+    assert run_pipeline(pipeline)


### PR DESCRIPTION
Adds a simple unit test for a pipeline execution. To do so I changed the code that the 'mara' db is optional during the pipeline execution:
* node cost is not taken from the database
* `RunLogger` will skip logging events to the database when 'mara' database is not defined