### PR TITLE
fix exitcode of process issue since python 3.8

### DIFF
--- a/mara_pipelines/execution.py
+++ b/mara_pipelines/execution.py
@@ -486,12 +486,12 @@ class TaskProcess:
             if self.is_alive():
                 return None
 
-            succeeded_from_queu = None
+            succeeded_from_queue = None
             try:
-                succeeded_from_queu = self._status_queue.get(False)
+                succeeded_from_queue = self._status_queue.get(False)
             except Empty:
                 pass
 
-            self._succeeded = (succeeded_from_queu == True and self._process.exitcode == 0)
+            self._succeeded = (succeeded_from_queue == True and self._process.exitcode == 0)
 
         return self._succeeded

--- a/mara_pipelines/execution.py
+++ b/mara_pipelines/execution.py
@@ -492,6 +492,6 @@ class TaskProcess:
             except Empty:
                 pass
 
-            self._succeeded = (succeeded_from_queue == True and self._process.exitcode == 0)
+            self._succeeded = succeeded_from_queue == True
 
         return self._succeeded

--- a/mara_pipelines/execution.py
+++ b/mara_pipelines/execution.py
@@ -268,7 +268,7 @@ def run_pipeline(pipeline: pipelines.Pipeline, nodes: {pipelines.Node} = None,
                                 message='★ ' + node_cost.format_duration(
                                     node_durations_and_run_times.get(tuple(next_node.path()), [0, 0])[0])))
 
-                            process = TaskProcess(next_node, event_queue)
+                            process = TaskProcess(next_node, event_queue, multiprocessing_context)
                             process.start()
                             running_task_processes[next_node] = process
 

--- a/tests/test_execute_pipeline.py
+++ b/tests/test_execute_pipeline.py
@@ -6,7 +6,10 @@ import mara_db.config
 patch(mara_db.config.databases)(lambda: {})
 
 
-def test_execute_without_db():
+def test_execute_without_db_success():
+    """
+    A simple test pipeline with a success run not using the mara database for logging.
+    """
     from mara_pipelines.commands.python import RunFunction
     from mara_pipelines.pipelines import Pipeline, Task
     from mara_pipelines.ui.cli import run_pipeline
@@ -24,3 +27,26 @@ def test_execute_without_db():
              commands=[RunFunction(function=command_function)]))
 
     assert run_pipeline(pipeline)
+
+
+def test_execute_without_db_failed():
+    """
+    A simple test pipeline with a failed run not using the mara database for logging.
+    """
+    from mara_pipelines.commands.python import RunFunction
+    from mara_pipelines.pipelines import Pipeline, Task
+    from mara_pipelines.ui.cli import run_pipeline
+
+    pipeline = Pipeline(
+        id='test_execute_without_db',
+        description="Tests if a pipeline can be executed without database")
+    
+    def command_function() -> bool:
+        return False
+
+    pipeline.add(
+        Task(id='run_python_function',
+             description="Runs a sample python function",
+             commands=[RunFunction(function=command_function)]))
+
+    assert not run_pipeline(pipeline)


### PR DESCRIPTION
The internal exitcode handling of a process changed since python 3.8 (https://github.com/python/cpython/issues/84275) which caused that when executing a pipeline through the UI the exit code from the process is 1 even when using `sys.exit(0)`. When we use the same multiprocessing context this seems to be handled properly in python and we get the correct exit code.