### PR TITLE
fix get_user_display_name on docker

### DIFF
--- a/mara_pipelines/logging/pipeline_events.py
+++ b/mara_pipelines/logging/pipeline_events.py
@@ -1,7 +1,6 @@
 """Events that are emitted during pipeline execution"""
 
 import datetime
-import json
 
 import enum
 import typing as t
@@ -10,7 +9,7 @@ from ..events import Event
 
 
 class PipelineEvent(Event):
-    def __init__(self, node_path: [str]) -> None:
+    def __init__(self, node_path: t.List[str]) -> None:
         """
         Base class for events that are emitted during a pipeline run.
 
@@ -23,7 +22,7 @@ class PipelineEvent(Event):
 
 
 class RunStarted(PipelineEvent):
-    def __init__(self, node_path: [str],
+    def __init__(self, node_path: t.List[str],
                  start_time: datetime.datetime,
                  pid: int,
                  is_root_pipeline: bool = False,
@@ -51,7 +50,7 @@ class RunStarted(PipelineEvent):
 
 
 class RunFinished(PipelineEvent):
-    def __init__(self, node_path: [str],
+    def __init__(self, node_path: t.List[str],
                  end_time: datetime.datetime,
                  succeeded: bool,
                  interactively_started: bool = False) -> None:
@@ -71,7 +70,7 @@ class RunFinished(PipelineEvent):
 
 
 class NodeStarted(PipelineEvent):
-    def __init__(self, node_path: [str], start_time: datetime.datetime, is_pipeline: bool) -> None:
+    def __init__(self, node_path: t.List[str], start_time: datetime.datetime, is_pipeline: bool) -> None:
         """
         A task run started.
         Args:
@@ -85,7 +84,7 @@ class NodeStarted(PipelineEvent):
 
 
 class NodeFinished(PipelineEvent):
-    def __init__(self, node_path: [str], start_time: datetime.datetime, end_time: datetime.datetime,
+    def __init__(self, node_path: t.List[str], start_time: datetime.datetime, end_time: datetime.datetime,
                  is_pipeline: bool, succeeded: bool) -> None:
         """
         A run of a task or pipeline finished.
@@ -110,7 +109,7 @@ class Output(PipelineEvent):
         VERBATIM = 'verbatim'
         ITALICS = 'italics'
 
-    def __init__(self, node_path: [str], message: str,
+    def __init__(self, node_path: t.List[str], message: str,
                  format: Format = Format.STANDARD, is_error: bool = False) -> None:
         """
         Some text output occurred.

--- a/mara_pipelines/logging/pipeline_events.py
+++ b/mara_pipelines/logging/pipeline_events.py
@@ -1,6 +1,8 @@
 """Events that are emitted during pipeline execution"""
 
 import datetime
+import os
+import getpass
 
 import enum
 import typing as t
@@ -136,13 +138,11 @@ def get_user_display_name(interactively_started: bool) -> t.Optional[str]:
 
     Patch if you have more sophisticated needs.
     """
-    import os
     if 'MARA_RUN_USER_DISPLAY_NAME' in os.environ:
         return os.environ.get('MARA_RUN_USER_DISPLAY_NAME')
     if not interactively_started:
         return None
     try:
-        import getpass
         return os.environ.get('SUDO_USER') or os.environ.get('USER') or getpass.getuser()
-    except:
+    except Exception: # pylint: disable=W0703
         return None

--- a/mara_pipelines/logging/pipeline_events.py
+++ b/mara_pipelines/logging/pipeline_events.py
@@ -142,4 +142,5 @@ def get_user_display_name(interactively_started: bool) -> t.Optional[str]:
         return os.environ.get('MARA_RUN_USER_DISPLAY_NAME')
     if not interactively_started:
         return None
-    return os.environ.get('SUDO_USER') or os.environ.get('USER') or os.getlogin()
+    import getpass
+    return os.environ.get('SUDO_USER') or os.environ.get('USER') or getpass.getuser()

--- a/mara_pipelines/logging/pipeline_events.py
+++ b/mara_pipelines/logging/pipeline_events.py
@@ -142,5 +142,8 @@ def get_user_display_name(interactively_started: bool) -> t.Optional[str]:
         return os.environ.get('MARA_RUN_USER_DISPLAY_NAME')
     if not interactively_started:
         return None
-    import getpass
-    return os.environ.get('SUDO_USER') or os.environ.get('USER') or getpass.getuser()
+    try:
+        import getpass
+        return os.environ.get('SUDO_USER') or os.environ.get('USER') or getpass.getuser()
+    except:
+        return None


### PR DESCRIPTION
On docker the `flask mara_pipelines.ui.run-interactively` fails with
![image](https://user-images.githubusercontent.com/67712864/214508420-1b0868bf-6644-4242-bcd3-eb5650364e0e.png)

This is a fix for this: According to the python documentation [os.getlogin()](https://docs.python.org/3/library/os.html#os.getlogin), `getpass.getuser()` should be used.