### PR TITLE
use generic cursor context

### DIFF
--- a/mara_pipelines/incremental_processing/file_dependencies.py
+++ b/mara_pipelines/incremental_processing/file_dependencies.py
@@ -6,7 +6,7 @@ import pathlib
 import sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
 
-import mara_db.postgresql
+import mara_db.dbs
 from .. import config
 
 Base = declarative_base()
@@ -32,7 +32,7 @@ def update(node_path: [str], dependency_type: str, pipeline_base_path: str, file
         pipeline_base_path: The base directory of the pipeline
         file_dependencies: A list of file names relative to pipeline_base_path
     """
-    with mara_db.postgresql.postgres_cursor_context('mara') as cursor:
+    with mara_db.dbs.cursor_context('mara') as cursor:
         cursor.execute(f"""
 INSERT INTO data_integration_file_dependency (node_path, dependency_type, hash, timestamp)
 VALUES ({'%s,%s,%s,%s'})
@@ -48,7 +48,7 @@ def delete(node_path: [str], dependency_type: str):
         node_path: The path of the node that depends on the files
         dependency_type: An arbitrary string that allows to distinguish between multiple dependencies of a node
     """
-    with mara_db.postgresql.postgres_cursor_context('mara') as cursor:
+    with mara_db.dbs.cursor_context('mara') as cursor:
         cursor.execute(f"""
 DELETE FROM data_integration_file_dependency
 WHERE node_path = {'%s'} AND dependency_type = {'%s'}
@@ -68,7 +68,7 @@ def is_modified(node_path: [str], dependency_type: str, pipeline_base_path: str,
     Returns: True when at least one of the files was modified
 
     """
-    with mara_db.postgresql.postgres_cursor_context('mara') as cursor:
+    with mara_db.dbs.cursor_context('mara') as cursor:
         cursor.execute("""
 SELECT TRUE
 FROM data_integration_file_dependency

--- a/mara_pipelines/incremental_processing/incremental_copy_status.py
+++ b/mara_pipelines/incremental_processing/incremental_copy_status.py
@@ -5,7 +5,6 @@ from sqlalchemy.ext.declarative import declarative_base
 
 import mara_db.config
 import mara_db.dbs
-import mara_db.postgresql
 
 Base = declarative_base()
 
@@ -31,7 +30,7 @@ def update(node_path: [str], source_db_alias: str, source_table: str, last_compa
     Returns:
 
     """
-    with mara_db.postgresql.postgres_cursor_context('mara') as cursor:
+    with mara_db.dbs.cursor_context('mara') as cursor:
         cursor.execute(f'''
 INSERT INTO data_integration_incremental_copy_status (node_path, source_table, last_comparison_value)
 VALUES ({'%s,%s,%s'})
@@ -50,7 +49,7 @@ def delete(node_path: [str], source_db_alias: str, source_table: str):
     Returns:
 
     """
-    with mara_db.postgresql.postgres_cursor_context('mara') as cursor:
+    with mara_db.dbs.cursor_context('mara') as cursor:
         cursor.execute(f'''
 DELETE FROM data_integration_incremental_copy_status
 WHERE node_path = {'%s'} AND source_table = {'%s'}
@@ -69,7 +68,7 @@ def get_last_comparison_value(node_path: [str], source_db_alias: str, source_tab
     Returns:
         The value or None
     """
-    with mara_db.postgresql.postgres_cursor_context('mara') as cursor:
+    with mara_db.dbs.cursor_context('mara') as cursor:
         cursor.execute(f"""
 SELECT last_comparison_value
 FROM data_integration_incremental_copy_status

--- a/mara_pipelines/incremental_processing/processed_files.py
+++ b/mara_pipelines/incremental_processing/processed_files.py
@@ -7,7 +7,6 @@ from sqlalchemy.ext.declarative import declarative_base
 
 import mara_db.config
 import mara_db.dbs
-import mara_db.postgresql
 
 Base = declarative_base()
 
@@ -32,7 +31,7 @@ def track_processed_file(node_path: str, file_name: str, last_modified_timestamp
 
     Returns: True
     """
-    with mara_db.postgresql.postgres_cursor_context('mara') as cursor:
+    with mara_db.dbs.cursor_context('mara') as cursor:
         cursor.execute(f'''
 INSERT INTO data_integration_processed_file (node_path, file_name, last_modified_timestamp) 
 VALUES ({'%s,%s,%s'})
@@ -51,7 +50,7 @@ def already_processed_files(node_path: str) -> {str: datetime}:
     Returns:
         A mapping of file names to timestamps of last modification
     """
-    with mara_db.postgresql.postgres_cursor_context('mara') as cursor:
+    with mara_db.dbs.cursor_context('mara') as cursor:
         cursor.execute(f"""
 SELECT file_name, last_modified_timestamp
 FROM data_integration_processed_file WHERE node_path = {'%s'}

--- a/mara_pipelines/incremental_processing/reset.py
+++ b/mara_pipelines/incremental_processing/reset.py
@@ -1,7 +1,7 @@
 """Resetting incremental copy status"""
 
 import mara_db.config
-import mara_db.postgresql
+import mara_db.dbs
 
 
 def reset_incremental_processing(node_path: [str]):
@@ -11,7 +11,7 @@ def reset_incremental_processing(node_path: [str]):
         node_path: The path of the node to reset
 
     """
-    with mara_db.postgresql.postgres_cursor_context('mara') as cursor:
+    with mara_db.dbs.cursor_context('mara') as cursor:
         cursor.execute(f'''
 SELECT *
 FROM

--- a/mara_pipelines/logging/node_cost.py
+++ b/mara_pipelines/logging/node_cost.py
@@ -4,7 +4,7 @@ import functools
 import math
 
 import mara_db.config
-import mara_db.postgresql
+import mara_db.dbs
 from .. import pipelines
 
 
@@ -19,7 +19,7 @@ def node_durations_and_run_times(node: pipelines.Node) -> {tuple: [float, float]
         A dictionary of {(node_path,): [avg_duration, avg_run_time]} entries for all children of `node`
 
     """
-    with mara_db.postgresql.postgres_cursor_context('mara') as cursor:
+    with mara_db.dbs.cursor_context('mara') as cursor:
         cursor.execute(f"""
 WITH child_nodes AS
        (SELECT node.node_path [ 0 : {'%(level)s'} + 1]                     AS node_path,

--- a/mara_pipelines/parallel_tasks/files.py
+++ b/mara_pipelines/parallel_tasks/files.py
@@ -10,7 +10,6 @@ from html import escape
 
 import mara_db.config
 import mara_db.dbs
-import mara_db.postgresql
 from mara_page import _, html
 
 from .. import config, pipelines
@@ -119,7 +118,7 @@ class _ParallelRead(pipelines.ParallelTask):
             if not isinstance(mara_db.dbs.db(self.db_alias), mara_db.dbs.PostgreSQLDB):
                 raise NotImplementedError(
                     f'Partitioning by day_id has only been implemented for postgresql so far, \n'
-                    f'not for {mara_db.postgresql.engine(self.db_alias).name}')
+                    f'not for {mara_db.dbs.db(self.db_alias)}')
             files_per_day = {}
             for (file, date) in files:
                 if date in files_per_day:

--- a/mara_pipelines/ui/run_time_chart.py
+++ b/mara_pipelines/ui/run_time_chart.py
@@ -2,10 +2,9 @@ import json
 import pathlib
 
 import flask
-import psycopg2.extensions
 
 import mara_db.config
-import mara_db.postgresql
+import mara_db.dbs
 from mara_page import acl, bootstrap, html, _
 from . import views
 from .. import pipelines
@@ -29,7 +28,7 @@ def run_time_chart(path: str):
 
     query = (pathlib.Path(__file__).parent / 'run_time_chart.sql').read_text()
 
-    with mara_db.postgresql.postgres_cursor_context('mara') as cursor:  # type: psycopg2.extensions.cursor
+    with mara_db.dbs.cursor_context('mara') as cursor:
         cursor.execute(query)
         cursor.execute(f'SELECT row_to_json(t) FROM pg_temp.node_run_times({"%s"}) t', (node.path(),))
         rows = [row[0] for row in cursor.fetchall()]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ license = MIT
 packages = mara_pipelines
 python_requires = >= 3.6
 install_requires =
-    mara-db>=4.7.1
+    mara-db>=4.9.1
     mara-page>=1.3.0
     graphviz>=0.8
     python-dateutil>=2.6.1


### PR DESCRIPTION
Use generic cursor context for future support of other database engines for the `mara` db.

Requires mara_db 4.9+