### PR TITLE
hide empty before/after task in ParallelTask

### DIFF
--- a/mara_pipelines/pipelines.py
+++ b/mara_pipelines/pipelines.py
@@ -133,8 +133,10 @@ class ParallelTask(Node):
     def launch(self) -> 'Pipeline':
         sub_pipeline = Pipeline(self.id, description=f'Runs f{self.id} in parallel',
                                 max_number_of_parallel_tasks=self.max_number_of_parallel_tasks)
-        sub_pipeline.add_initial(Task(id='before', description='Runs commands-before', commands=self.commands_before))
-        sub_pipeline.add_final(Task(id='after', description='Runs commands-after', commands=self.commands_after))
+        if self.commands_before:
+            sub_pipeline.add_initial(Task(id='before', description='Runs commands-before', commands=self.commands_before))
+        if self.commands_after:
+            sub_pipeline.add_final(Task(id='after', description='Runs commands-after', commands=self.commands_after))
 
         self.add_parallel_tasks(sub_pipeline)
 


### PR DESCRIPTION
Hides the empty tasks in the internal pipeline behind `ParallelTask` when `commands_before` and `commands_after` of the parallel task is empty.

![image](https://user-images.githubusercontent.com/67712864/218778124-3bfedd16-b02c-4c2d-91b7-af2c9d02e614.png)

![image](https://user-images.githubusercontent.com/67712864/218778143-7d2d14f9-5d0a-47a6-b343-3f9c2d1e61a6.png)
