### PR TITLE
fix SQLAlchemy warning about declarative_base moved in 2.0

### DIFF
--- a/mara_pipelines/incremental_processing/file_dependencies.py
+++ b/mara_pipelines/incremental_processing/file_dependencies.py
@@ -5,7 +5,7 @@ import pathlib
 from typing import List
 
 import sqlalchemy
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 import mara_db.dbs
 from .. import config

--- a/mara_pipelines/incremental_processing/incremental_copy_status.py
+++ b/mara_pipelines/incremental_processing/incremental_copy_status.py
@@ -3,7 +3,7 @@
 from typing import List
 
 import sqlalchemy
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 import mara_db.config
 import mara_db.dbs

--- a/mara_pipelines/incremental_processing/processed_files.py
+++ b/mara_pipelines/incremental_processing/processed_files.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Dict
 
 import sqlalchemy
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 import mara_db.config
 import mara_db.dbs

--- a/mara_pipelines/logging/run_log.py
+++ b/mara_pipelines/logging/run_log.py
@@ -3,7 +3,7 @@
 from typing import List, Dict
 
 import sqlalchemy.orm
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from .. import config
 from ..logging import pipeline_events, system_statistics

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     more-itertools>=3.1.0
     psutil>=5.4.0
     requests>=2.19.1
+    SQLAlchemy>=1.4
 
 [options.package_data]
 mara_pipelines = **/*.py, **/*.sql, ui/static/*


### PR DESCRIPTION
fixes the following SQLAlchemy warning:

![image](https://user-images.githubusercontent.com/67712864/221409634-087fee06-ac79-4e2f-a746-b6ac190b9cf8.png)
